### PR TITLE
Add status to klage view class

### DIFF
--- a/src/main/kotlin/no/nav/klage/domain/klage/KlageView.kt
+++ b/src/main/kotlin/no/nav/klage/domain/klage/KlageView.kt
@@ -11,6 +11,7 @@ data class KlageView(
     val tema: Tema,
     val ytelse: String,
     val vedtak: String,
+    val status: KlageStatus = KlageStatus.DRAFT,
     val saksnummer: String? = null,
     val vedlegg: List<VedleggView> = listOf(),
     val journalpostId: String? = null,

--- a/src/main/kotlin/no/nav/klage/service/KlageService.kt
+++ b/src/main/kotlin/no/nav/klage/service/KlageService.kt
@@ -114,6 +114,7 @@ class KlageService(
             tema,
             ytelse,
             vedtak,
+            status,
             saksnummer,
             vedlegg.map {
                 if (expandVedleggToVedleggView) {


### PR DESCRIPTION
Legger til `status` i `KlageView` med default verdi `KlageStatus.DRAFT`.
Denne `enum`-en blir serialisert som en `string` (f.eks. `DRAFT`) og skal brukes av frontend snart ift. å fortsette klager og se status på klager.