### PR TITLE
Add modified datetime to klage view

### DIFF
--- a/src/main/kotlin/no/nav/klage/domain/klage/KlageView.kt
+++ b/src/main/kotlin/no/nav/klage/domain/klage/KlageView.kt
@@ -4,6 +4,10 @@ import no.nav.klage.domain.Bruker
 import no.nav.klage.domain.Tema
 import no.nav.klage.domain.vedlegg.VedleggView
 import no.nav.klage.domain.vedlegg.toVedlegg
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 data class KlageView(
     val id: Int,
@@ -12,6 +16,7 @@ data class KlageView(
     val ytelse: String,
     val vedtak: String,
     val status: KlageStatus = KlageStatus.DRAFT,
+    val modifiedByUser: LocalDateTime = ZonedDateTime.ofInstant(Instant.now(), ZoneId.of("Europe/Oslo")).toLocalDateTime(),
     val saksnummer: String? = null,
     val vedlegg: List<VedleggView> = listOf(),
     val journalpostId: String? = null,

--- a/src/main/kotlin/no/nav/klage/service/KlageService.kt
+++ b/src/main/kotlin/no/nav/klage/service/KlageService.kt
@@ -19,6 +19,8 @@ import no.nav.slackposter.SlackClient
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 @Service
 @Transactional
@@ -115,6 +117,7 @@ class KlageService(
             ytelse,
             vedtak,
             status,
+            ZonedDateTime.ofInstant((modifiedByUser ?: Instant.now()), ZoneId.of("Europe/Oslo")).toLocalDateTime(),
             saksnummer,
             vedlegg.map {
                 if (expandVedleggToVedleggView) {


### PR DESCRIPTION
Eksponerer `modifiedByUser` som `LocalDateTime` (f.eks. `"2020-10-29T12:41:05.801997"`).
Til fremtidig bruk av frontend ift. visning av klager og å fortsette påbegynte klager.