### PR TITLE
Remove referrer from klage view and metrics

### DIFF
--- a/src/main/kotlin/no/nav/klage/common/KlageMetrics.kt
+++ b/src/main/kotlin/no/nav/klage/common/KlageMetrics.kt
@@ -12,7 +12,6 @@ class KlageMetrics(private val meterRegistry: MeterRegistry) {
         private val logger = getLogger(javaClass.enclosingClass)
 
         private const val COUNTER_KLAGER_FINALIZED = "klager_finalized"
-        private const val COUNTER_KLAGER_REFERRER = "klager_referrer"
         private const val COUNTER_KLAGER_INITIALIZED = "klager_initialized"
     }
 
@@ -21,14 +20,6 @@ class KlageMetrics(private val meterRegistry: MeterRegistry) {
             meterRegistry.counter(COUNTER_KLAGER_INITIALIZED).increment()
         } catch (e: Exception) {
             logger.warn("incrementKlagerInitialized failed", e)
-        }
-    }
-
-    fun incrementReferrer(referrer: String) {
-        try {
-            meterRegistry.counter(COUNTER_KLAGER_REFERRER, "referrer", referrer).increment()
-        } catch (e: Exception) {
-            logger.warn("incrementReferrer failed", e)
         }
     }
 

--- a/src/main/kotlin/no/nav/klage/domain/klage/KlageView.kt
+++ b/src/main/kotlin/no/nav/klage/domain/klage/KlageView.kt
@@ -17,8 +17,7 @@ data class KlageView(
     val saksnummer: String? = null,
     val vedlegg: List<VedleggView> = listOf(),
     val journalpostId: String? = null,
-    val finalizedDate: LocalDate? = null,
-    val referrer: String? = null
+    val finalizedDate: LocalDate? = null
 )
 
 fun KlageView.toKlage(bruker: Bruker, status: KlageStatus = KlageStatus.DRAFT) = Klage(

--- a/src/main/kotlin/no/nav/klage/service/KlageService.kt
+++ b/src/main/kotlin/no/nav/klage/service/KlageService.kt
@@ -61,7 +61,6 @@ class KlageService(
     fun createKlage(klage: KlageView, bruker: Bruker): KlageView {
         return klageRepository.createKlage(klage.toKlage(bruker, DRAFT)).toKlageView(bruker).also {
             klageMetrics.incrementKlagerInitialized()
-            klageMetrics.incrementReferrer(if (klage.referrer.isNullOrBlank()) "none" else klage.referrer)
         }
     }
 


### PR DESCRIPTION
Denne PRen fjerner `referrer` fra `KlageView` og metrics.