### PR TITLE
Add finalized date to klage view

### DIFF
--- a/src/main/kotlin/no/nav/klage/domain/klage/KlageView.kt
+++ b/src/main/kotlin/no/nav/klage/domain/klage/KlageView.kt
@@ -4,10 +4,7 @@ import no.nav.klage.domain.Bruker
 import no.nav.klage.domain.Tema
 import no.nav.klage.domain.vedlegg.VedleggView
 import no.nav.klage.domain.vedlegg.toVedlegg
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZonedDateTime
+import java.time.*
 
 data class KlageView(
     val id: Int,
@@ -20,6 +17,7 @@ data class KlageView(
     val saksnummer: String? = null,
     val vedlegg: List<VedleggView> = listOf(),
     val journalpostId: String? = null,
+    val finalizedDate: LocalDate? = null,
     val referrer: String? = null
 )
 

--- a/src/main/kotlin/no/nav/klage/service/KlageService.kt
+++ b/src/main/kotlin/no/nav/klage/service/KlageService.kt
@@ -109,26 +109,29 @@ class KlageService(
         return fileClient.getKlageFile(existingKlage.journalpostId)
     }
 
-    fun Klage.toKlageView(bruker: Bruker, expandVedleggToVedleggView: Boolean = true) =
-        KlageView(
-            id!!,
-            fritekst,
-            tema,
-            ytelse,
-            vedtak,
-            status,
-            ZonedDateTime.ofInstant((modifiedByUser ?: Instant.now()), ZoneId.of("Europe/Oslo")).toLocalDateTime(),
-            saksnummer,
-            vedlegg.map {
-                if (expandVedleggToVedleggView) {
-                    vedleggService.expandVedleggToVedleggView(
-                        it,
-                        bruker
-                    )
-                } else {
-                    it.toVedleggView("")
-                }
-            },
-            journalpostId
+    fun Klage.toKlageView(bruker: Bruker, expandVedleggToVedleggView: Boolean = true): KlageView {
+        val modifiedDateTime = ZonedDateTime.ofInstant((modifiedByUser ?: Instant.now()), ZoneId.of("Europe/Oslo")).toLocalDateTime()
+        return KlageView(
+                id!!,
+                fritekst,
+                tema,
+                ytelse,
+                vedtak,
+                status,
+                modifiedDateTime,
+                saksnummer,
+                vedlegg.map {
+                    if (expandVedleggToVedleggView) {
+                        vedleggService.expandVedleggToVedleggView(
+                                it,
+                                bruker
+                        )
+                    } else {
+                        it.toVedleggView("")
+                    }
+                },
+                journalpostId,
+                finalizedDate = if (status === DONE) modifiedDateTime.toLocalDate() else null
         )
+    }
 }


### PR DESCRIPTION
Denne PRen legger til `finalizedDate` på `KlageView`.
`finalizedDate` blir satt til `LocalDate` dersom `status` er `DONE` og `null` ellers.

**Hvorfor?**
I de fleste tilfeller vil `finalizedDate` være `null`.
I de tilfellene der en klage er innsendt og vi trenger å vise kvittering, oppsummering e.l. for klagen trenger vi også `finalizedDate`. I dag blir `finalizedDate` kun sendt i svar for `/klager/:id/finalize` og er deretter ikke tilgjengelig.

Tanken er at det er backend som eier denne datoen og at det er ryddig å få denne med klagen.
Dette gjør også at frontend sin type for en `Klage` kan fortsette å matche backend sin klasse for `KlageView`.
Det er heller ingen stor kost å sende med denne datoen fra backend.

**Alternativ løsning**
Siden frontend har både `status` og `modifiedByUser`, kan denne logikken gjøres i frontend-koden.