### PR TITLE
Allow certain operations on finalized klager

### DIFF
--- a/src/main/kotlin/no/nav/klage/controller/KlageController.kt
+++ b/src/main/kotlin/no/nav/klage/controller/KlageController.kt
@@ -121,7 +121,7 @@ class KlageController(
     @ResponseStatus(HttpStatus.OK)
     fun finalizeKlage(
         @PathVariable klageId: Int
-    ): Map<String, LocalDate> {
+    ): Map<String, String> {
         val bruker = brukerService.getBruker()
         logger.debug("Finalize klage is requested. Id: {}", klageId)
         secureLogger.debug(
@@ -130,7 +130,11 @@ class KlageController(
             bruker.folkeregisteridentifikator.identifikasjonsnummer
         )
         val finalizedInstant = klageService.finalizeKlage(klageId, bruker)
-        return mapOf("finalizedDate" to ZonedDateTime.ofInstant(finalizedInstant, ZoneId.of("Europe/Oslo")).toLocalDate())
+        val zonedDateTime = ZonedDateTime.ofInstant(finalizedInstant, ZoneId.of("Europe/Oslo"))
+        return mapOf(
+                "finalizedDate" to zonedDateTime.toLocalDate().toString(),
+                "modifiedByUser" to zonedDateTime.toLocalDateTime().toString()
+        )
     }
 
     @PostMapping(value = ["/klager/{klageId}/vedlegg"], consumes = ["multipart/form-data"])

--- a/src/main/kotlin/no/nav/klage/domain/klage/Klage.kt
+++ b/src/main/kotlin/no/nav/klage/domain/klage/Klage.kt
@@ -22,11 +22,5 @@ enum class KlageStatus {
     DRAFT, DONE, DELETED
 }
 
-fun Klage.validateAccess(currentIdentifikasjonsnummer: String, checkFinalized: Boolean = true) {
-    if (checkFinalized && status === KlageStatus.DONE) {
-        throw RuntimeException("Klage is already finalized.")
-    }
-    if (foedselsnummer != currentIdentifikasjonsnummer) {
-        throw RuntimeException("Folkeregisteridentifikator in klage does not match current user.")
-    }
-}
+fun Klage.validateAccess(currentIdentifikasjonsnummer: String) = (foedselsnummer == currentIdentifikasjonsnummer)
+fun Klage.isFinalized() = (status === KlageStatus.DONE)


### PR DESCRIPTION
`Klage.validateAccess()` hadde et par problemer:

1. Den validerte først om klagen var `finalized`, deretter om brukeren eide den. Dvs. at alle brukere kan finne ut om andres spesifikke klager er sendt inn eller ikke. Når vi i tillegg har løpenummer som ID på klagene blir det veldig enkelt å gå igjennom alle klagene og sjekke.
2. Metoden sjekket både om brukeren eier klagen og om den er `finalized` som default, som ikke alltid var hensiktsmessig. Det er f.eks. ingen grunn til å ikke tillate flere kall til `/finalize`, så lenge vi håndterer det riktig.

De to sjekkene er nå skilt fra hverandre og kalt eksplisitt der de trengs. Dvs. at selv om `fun finalizeKlage()` ser ut til å ikke være endret i denne PRen, så er den det fordi `Klage.validateAccess()` sin funksjonalitet er endret.