### PR TITLE
No longer uses Vedtak in KlageView and Klage. 

### DIFF
--- a/src/main/kotlin/no/nav/klage/domain/AggregatedKlage.kt
+++ b/src/main/kotlin/no/nav/klage/domain/AggregatedKlage.kt
@@ -31,10 +31,7 @@ fun createAggregatedKlage(
     bruker: Bruker,
     klage: Klage
 ): AggregatedKlage {
-    var vedtak = klage.vedtak
-    if (klage.vedtakType != null || klage.vedtakDate != null) {
-        vedtak = vedtakFromTypeAndDate(klage.vedtakType, klage.vedtakDate)
-    }
+    val vedtak = vedtakFromTypeAndDate(klage.vedtakType, klage.vedtakDate)
 
     return AggregatedKlage(
         id = klage.id!!,
@@ -55,7 +52,5 @@ fun createAggregatedKlage(
         ytelse = klage.ytelse,
         vedlegg = klage.vedlegg
     )
-
-
 }
 

--- a/src/main/kotlin/no/nav/klage/domain/klage/Klage.kt
+++ b/src/main/kotlin/no/nav/klage/domain/klage/Klage.kt
@@ -13,7 +13,6 @@ data class Klage(
     val modifiedByUser: Instant? = Instant.now(),
     val tema: Tema,
     val ytelse: String,
-    val vedtak: String? = null,
     val saksnummer: String? = null,
     val vedlegg: List<Vedlegg> = listOf(),
     val journalpostId: String? = null,

--- a/src/main/kotlin/no/nav/klage/domain/klage/KlageDAO.kt
+++ b/src/main/kotlin/no/nav/klage/domain/klage/KlageDAO.kt
@@ -54,7 +54,6 @@ fun KlageDAO.toKlage(): Klage {
         modifiedByUser = this.modifiedByUser,
         tema = this.tema.toTema(),
         ytelse = this.ytelse,
-        vedtak = this.vedtak,
         saksnummer = this.saksnummer,
         vedlegg = this.vedlegg.map { it.toVedlegg() },
         journalpostId = this.journalpostId,
@@ -62,11 +61,7 @@ fun KlageDAO.toKlage(): Klage {
         vedtakDate = this.vedtakDate
     )
 
-    outputKlage = if (this.vedtakType != null || this.vedtakDate != null) {
-        //Fyller ut gammel vedtaksform basert på ny form
-        outputKlage.copy(vedtak = vedtakFromTypeAndDate(this.vedtakType.toVedtakType(), this.vedtakDate))
-    } else if (this.vedtak != null) {
-        //Fyller ut nye vedtaksformer basert på gamle
+    outputKlage = if (this.vedtak != null && (this.vedtakType == null && this.vedtakDate == null)) {
         outputKlage.copy(
             vedtakType = vedtakTypeFromVedtak(this.vedtak!!),
             vedtakDate = vedtakDateFromVedtak(this.vedtak!!)
@@ -94,14 +89,6 @@ fun String?.toVedtakType() =
     if (this != null) VedtakType.valueOf(this) else null
 
 fun KlageDAO.fromKlage(klage: Klage) {
-    var outputVedtakType = klage.vedtakType
-    var outputVedtakDate = klage.vedtakDate
-
-    if (klage.vedtak != null && outputVedtakType == null && outputVedtakDate == null) {
-        outputVedtakDate = vedtakDateFromVedtak(klage.vedtak)
-        outputVedtakType = vedtakTypeFromVedtak(klage.vedtak)
-    }
-
     foedselsnummer = klage.foedselsnummer
     fritekst = klage.fritekst
     status = klage.status.name
@@ -111,6 +98,6 @@ fun KlageDAO.fromKlage(klage: Klage) {
     vedtak = null
     klage.saksnummer?.let { saksnummer = it }
     klage.journalpostId?.let { journalpostId = it }
-    vedtakType = outputVedtakType?.name
-    vedtakDate = outputVedtakDate
+    vedtakType = klage.vedtakType?.name
+    vedtakDate = klage.vedtakDate
 }

--- a/src/main/kotlin/no/nav/klage/domain/klage/KlageView.kt
+++ b/src/main/kotlin/no/nav/klage/domain/klage/KlageView.kt
@@ -11,7 +11,6 @@ data class KlageView(
     val fritekst: String,
     val tema: Tema,
     val ytelse: String,
-    val vedtak: String? = null,
     val status: KlageStatus = KlageStatus.DRAFT,
     val modifiedByUser: LocalDateTime = ZonedDateTime.ofInstant(Instant.now(), ZoneId.of("Europe/Oslo"))
         .toLocalDateTime(),
@@ -30,7 +29,6 @@ fun KlageView.toKlage(bruker: Bruker, status: KlageStatus = KlageStatus.DRAFT) =
     status = status,
     tema = tema,
     ytelse = ytelse,
-    vedtak = vedtak,
     saksnummer = saksnummer,
     vedlegg = vedlegg.map { it.toVedlegg() },
     journalpostId = journalpostId,

--- a/src/main/kotlin/no/nav/klage/service/KlageService.kt
+++ b/src/main/kotlin/no/nav/klage/service/KlageService.kt
@@ -142,7 +142,6 @@ class KlageService(
             fritekst,
             tema,
             ytelse,
-            vedtak,
             status,
             modifiedDateTime,
             saksnummer,

--- a/src/test/kotlin/no/nav/klage/domain/KlageConversionTest.kt
+++ b/src/test/kotlin/no/nav/klage/domain/KlageConversionTest.kt
@@ -8,7 +8,6 @@ import org.h2.jdbcx.JdbcConnectionPool
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -55,182 +54,45 @@ class KlageConversionTest {
     inner class KlageDAOToKlage {
 
         @Nested
-        inner class VedtakBasedOnVedtakTypeAndVedtakDate {
-
-            @Test
-            fun `should populate earlier vedtak with date in Klage based on vedtakType and vedtakDate in KlageDAO`() {
-                val klageInDB = templateKlage.copy(vedtakType = VedtakType.EARLIER, vedtakDate = vedtakDate)
-                val expectedOutput = klageInDB.copy(vedtak = earlierVedtakWithDate)
-
-                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB)
-            }
-
-            @Test
-            fun `should populate earlier vedtak without date in Klage based on vedtakType in KlageDAO`() {
-                val klageInDB = templateKlage.copy(vedtakType = VedtakType.EARLIER)
-                val expectedOutput = klageInDB.copy(vedtak = earlierVedtak)
-
-                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB)
-            }
-
-            @Test
-            fun `should populate latest vedtak without date in Klage based on vedtakType in KlageDAO`() {
-                val klageInDB = templateKlage.copy(vedtakType = VedtakType.LATEST)
-                val expectedOutput = klageInDB.copy(vedtak = latestVedtak)
-
-                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB)
-            }
-
-            @Test
-            fun `should populate latest vedtak without date in Klage based on vedtakType and vedtakDate in KlageDAO`() {
-                val klageInDB = templateKlage.copy(vedtakType = VedtakType.LATEST, vedtakDate = vedtakDate)
-                val expectedOutput = klageInDB.copy(vedtak = latestVedtak)
-
-                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB)
-            }
-
-            @Test
-            fun `should populate earlier vedtak with date in Klage based on vedtakType and vedtakDate in KlageDAO, ignoring vedtak in KlageDAO`() {
-                val klageInDB = templateKlage.copy(
-                    vedtak = earlierVedtakWithDateVersion2,
-                    vedtakType = VedtakType.EARLIER,
-                    vedtakDate = vedtakDate
-                )
-                val expectedOutput = klageInDB.copy(vedtak = earlierVedtakWithDate)
-
-                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB)
-            }
-
-        }
-
-        @Nested
         inner class VedtakTypeAndVedtakDateBasedOnVedtak {
 
             @Test
             fun `should populate vedtakDate and vedtakType in Klage based on earlier vedtak with date in KlageDAO`() {
-                val klageInDB = templateKlage.copy(vedtak = earlierVedtakWithDate)
+                val klageInDB = templateKlage
                 val expectedOutput = klageInDB.copy(vedtakType = VedtakType.EARLIER, vedtakDate = vedtakDate)
 
-                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB)
+                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB, earlierVedtakWithDate)
             }
 
             @Test
             fun `should populate vedtakType in Klage based on earlier vedtak without date in KlageDAO`() {
-                val klageInDB = templateKlage.copy(vedtak = earlierVedtak)
+                val klageInDB = templateKlage
                 val expectedOutput = klageInDB.copy(vedtakType = VedtakType.EARLIER)
 
-                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB)
+                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB, earlierVedtak)
             }
 
             @Test
             fun `should populate vedtakType in Klage based on latest vedtak without date in KlageDAO`() {
-                val klageInDB = templateKlage.copy(vedtak = latestVedtak)
+                val klageInDB = templateKlage
                 val expectedOutput = klageInDB.copy(vedtakType = VedtakType.LATEST)
 
-                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB)
+                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB, latestVedtak)
             }
 
             @Test
             fun `should populate vedtak, vedtakDate and vedtakType in Klage based on corresponding date and type values in KlageDAO, ignoring existing vedtak`() {
                 val klageInDB = templateKlage.copy(
                     vedtakType = VedtakType.EARLIER,
-                    vedtakDate = vedtakDate,
-                    vedtak = earlierVedtakWithDateVersion2
-                )
-                val expectedOutput = klageInDB.copy(
-                    vedtakType = VedtakType.EARLIER,
-                    vedtakDate = vedtakDate,
-                    vedtak = earlierVedtakWithDate
+                    vedtakDate = vedtakDate
                 )
 
-                verifyConversionToKlageFromKlageDAO(expectedOutput, klageInDB)
+                verifyConversionToKlageFromKlageDAO(klageInDB, klageInDB, earlierVedtakWithDateVersion2)
             }
         }
     }
 
-    @Nested
-    inner class KlageToKlageDAO {
-        @Test
-        fun `should populate vedtakType and vedtakDate in KlageDAO based on earlier vedtak with date in Klage`() {
-            val inputKlage = templateKlage.copy(vedtak = earlierVedtakWithDate)
-
-            transaction {
-                val result = KlageDAO.new {
-                    fromKlage(inputKlage)
-                }
-
-                assertEquals(VedtakType.EARLIER.name, result.vedtakType)
-                assertEquals(vedtakDate, result.vedtakDate)
-                assertNull(result.vedtak)
-            }
-        }
-
-        @Test
-        fun `should populate vedtakType in KlageDAO based on earlier vedtak without date in Klage`() {
-            val inputKlage = templateKlage.copy(vedtak = earlierVedtak)
-
-            transaction {
-                val result = KlageDAO.new {
-                    fromKlage(inputKlage)
-                }
-
-                assertEquals(VedtakType.EARLIER.name, result.vedtakType)
-                assertNull(result.vedtakDate)
-                assertNull(result.vedtak)
-            }
-        }
-
-        @Test
-        fun `should populate vedtakType in KlageDAO based on latest vedtak in Klage`() {
-            val inputKlage = templateKlage.copy(vedtak = latestVedtak)
-
-            transaction {
-                val result = KlageDAO.new {
-                    fromKlage(inputKlage)
-                }
-
-                assertEquals(VedtakType.LATEST.name, result.vedtakType)
-                assertNull(result.vedtakDate)
-                assertNull(result.vedtak)
-            }
-        }
-
-        @Test
-        fun `should populate vedtakType and vedtakDate in KlageDAO based on corresponding values in Klage, ignoring vedtak`() {
-            val inputKlage = templateKlage.copy(
-                vedtak = earlierVedtakWithDateVersion2,
-                vedtakType = VedtakType.EARLIER,
-                vedtakDate = vedtakDate
-            )
-
-            transaction {
-                val result = KlageDAO.new {
-                    fromKlage(inputKlage)
-                }
-
-                assertEquals(VedtakType.EARLIER.name, result.vedtakType)
-                assertEquals(vedtakDate, result.vedtakDate)
-                assertNull(result.vedtak)
-            }
-        }
-
-        @Test
-        fun `should populate vedtakDate in KlageDAO based on corresponding value in Klage, ignoring vedtak`() {
-            val inputKlage = templateKlage.copy(vedtak = earlierVedtakWithDate, vedtakDate = vedtakDate)
-
-            transaction {
-                val result = KlageDAO.new {
-                    fromKlage(inputKlage)
-                }
-
-                assertNull(result.vedtakType)
-                assertEquals(vedtakDate, result.vedtakDate)
-                assertNull(result.vedtak)
-            }
-        }
-    }
-
-    private fun verifyConversionToKlageFromKlageDAO(expectedOutput: Klage, klageInDB: Klage) {
+    private fun verifyConversionToKlageFromKlageDAO(expectedOutput: Klage, klageInDB: Klage, vedtakInKlage: String? = null) {
         transaction {
             val inputKlageDAO = KlageDAO.new {
                 foedselsnummer = klageInDB.foedselsnummer
@@ -238,7 +100,7 @@ class KlageConversionTest {
                 fritekst = klageInDB.fritekst
                 tema = klageInDB.tema.name
                 ytelse = klageInDB.ytelse
-                vedtak = klageInDB.vedtak
+                vedtak = vedtakInKlage
                 vedtakType = klageInDB.vedtakType?.name
                 vedtakDate = klageInDB.vedtakDate
             }

--- a/src/test/kotlin/no/nav/klage/repository/KlageRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/klage/repository/KlageRepositoryTest.kt
@@ -51,7 +51,6 @@ class KlageRepositoryTest {
         foedselsnummer = "123455667",
         fritekst = fritekst,
         tema = Tema.AAP,
-        ytelse = "Foreldrepenger",
-        vedtak = "some date"
+        ytelse = "Foreldrepenger"
     )
 }

--- a/src/test/kotlin/no/nav/klage/repository/VedleggRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/klage/repository/VedleggRepositoryTest.kt
@@ -58,9 +58,9 @@ class VedleggRepositoryTest {
         foedselsnummer = "123455667",
         fritekst = "fritekst",
         tema = Tema.AAP,
-        ytelse = "Foreldrepenger",
-        vedtak = "some date"
+        ytelse = "Foreldrepenger"
     )
 
-    private val vedlegg1 = MockMultipartFile("vedlegg.txt", "vedlegg.txt", "txt", "file".toByteArray(Charset.defaultCharset()))
+    private val vedlegg1 =
+        MockMultipartFile("vedlegg.txt", "vedlegg.txt", "txt", "file".toByteArray(Charset.defaultCharset()))
 }


### PR DESCRIPTION
Removed unused conversion to Vedtak. Kept support for conversion from Vedtak in DB to Klage, for legacy purpose. Keeps Vedtak in AggregatedKlage sent to klage-arkiver-journalpost, based on type and date.